### PR TITLE
Add Support for Has-and-Belongs-to-Many Associations

### DIFF
--- a/lib/sprig/reap.rb
+++ b/lib/sprig/reap.rb
@@ -6,6 +6,7 @@ module Sprig::Reap
   autoload :Configuration, 'sprig/reap/configuration'
   autoload :Model,         'sprig/reap/model'
   autoload :Association,   'sprig/reap/association'
+  autoload :Value,         'sprig/reap/value'
   autoload :Record,        'sprig/reap/record'
   autoload :SeedFile,      'sprig/reap/seed_file'
   autoload :FileAttribute, 'sprig/reap/file_attribute'

--- a/lib/sprig/reap/association.rb
+++ b/lib/sprig/reap/association.rb
@@ -2,7 +2,7 @@ module Sprig::Reap
   class Association
     attr_reader :association
 
-    delegate :foreign_key, :to => :association
+    delegate :plural_name, :to => :association
 
     def initialize(association)
       @association = association
@@ -37,6 +37,18 @@ module Sprig::Reap
 
     def polymorphic_type
       polymorphic? ? association.foreign_type : nil
+    end
+
+    def has_and_belongs_to_many?
+      association.macro == :has_and_belongs_to_many
+    end
+
+    def has_and_belongs_to_many_attr
+      association.association_foreign_key.pluralize if has_and_belongs_to_many?
+    end
+
+    def foreign_key
+      has_and_belongs_to_many? ? association.association_foreign_key : association.foreign_key
     end
   end
 end

--- a/lib/sprig/reap/model.rb
+++ b/lib/sprig/reap/model.rb
@@ -32,7 +32,7 @@ module Sprig::Reap
     end
 
     def associations
-      @associations ||= klass.reflect_on_all_associations(:belongs_to).map do |association|
+      @associations ||= klass.reflect_on_all_associations.select(&has_dependencies?).map do |association|
         Association.new(association)
       end
     end
@@ -76,6 +76,12 @@ module Sprig::Reap
     end
 
     private
+
+    def has_dependencies?
+      proc do |association|
+        %i(belongs_to has_and_belongs_to_many).include? association.macro
+      end
+    end
 
     def self.tsorted_classes(models)
       models.reduce(TsortableHash.new) do |hash, model|

--- a/lib/sprig/reap/model.rb
+++ b/lib/sprig/reap/model.rb
@@ -79,7 +79,7 @@ module Sprig::Reap
 
     def has_dependencies?
       proc do |association|
-        %i(belongs_to has_and_belongs_to_many).include? association.macro
+        [:belongs_to, :has_and_belongs_to_many].include? association.macro
       end
     end
 

--- a/lib/sprig/reap/model.rb
+++ b/lib/sprig/reap/model.rb
@@ -80,7 +80,7 @@ module Sprig::Reap
     def self.tsorted_classes(models)
       models.reduce(TsortableHash.new) do |hash, model|
         hash.merge(model.klass => model.dependencies)
-      end.tsort
+      end.resolve_circular_hatbm_dependencies!.tsort
     end
   end
 end

--- a/lib/sprig/reap/model.rb
+++ b/lib/sprig/reap/model.rb
@@ -86,7 +86,7 @@ module Sprig::Reap
     def self.tsorted_classes(models)
       models.reduce(TsortableHash.new) do |hash, model|
         hash.merge(model.klass => model.dependencies)
-      end.resolve_circular_hatbm_dependencies!.tsort
+      end.resolve_circular_habtm_dependencies!.tsort
     end
   end
 end

--- a/lib/sprig/reap/record.rb
+++ b/lib/sprig/reap/record.rb
@@ -3,7 +3,7 @@ module Sprig::Reap
     attr_reader :record, :model
     attr_writer :sprig_id
 
-    delegate :id, to: :record
+    delegate :id, :to => :record
 
     def initialize(record, model)
       @record = record
@@ -11,14 +11,14 @@ module Sprig::Reap
     end
 
     def attributes
-      @attributes ||= model.attributes.delete_if { |a| a == "id" }
+      @attributes ||= model.attributes.delete_if { |a| a == "id" } | model.associations.map(&:has_and_belongs_to_many_attr).compact
     end
 
     def to_hash
       attributes.reduce({"sprig_id" => sprig_id}) do |hash, attr|
-        value = get_value_for(attr)
+        value = Value.for(self, attr)
 
-        if Sprig::Reap.omit_empty_attrs && value.nil?
+        if Sprig::Reap.omit_empty_attrs && empty?(value)
           hash
         else
           hash.merge(attr => value)
@@ -32,46 +32,8 @@ module Sprig::Reap
 
     private
 
-    def get_value_for(attr)
-      if dependency?(attr)
-        klass    = klass_for(attr)
-        id       = record.send(attr)
-        sprig_id = Model.find(klass, id).try(:sprig_id)
-
-        sprig_record(klass, sprig_id)
-      else
-        read_attribute attr
-      end
-    end
-
-    def dependency?(attr)
-      attr.in? model.associations.map(&:foreign_key)
-    end
-
-    def klass_for(foreign_key)
-      association = association_for(foreign_key)
-
-      if association.polymorphic?
-        record.send(association.polymorphic_type).constantize
-      else
-        association.klass
-      end
-    end
-
-    def association_for(foreign_key)
-      model.associations.detect { |a| a.foreign_key == foreign_key }
-    end
-
-    def sprig_record(klass, sprig_id)
-      return if sprig_id.nil?
-
-      "<%= sprig_record(#{klass}, #{sprig_id}).id %>"
-    end
-
-    def read_attribute(attr)
-      file_attr = FileAttribute.new(record.send(attr))
-
-      file_attr.file.try(:sprig_location) || record.read_attribute(attr)
+    def empty?(value)
+      value.respond_to?(:empty?) ? value.empty? : value.nil?
     end
   end
 end

--- a/lib/sprig/reap/tsortable_hash.rb
+++ b/lib/sprig/reap/tsortable_hash.rb
@@ -8,14 +8,14 @@ module Sprig::Reap
       fetch(node).each(&block)
     end
 
-    def resolve_circular_hatbm_dependencies!
+    def resolve_circular_habtm_dependencies!
       # When two models each have a `has_and_belongs_to_many` association pointing to the other,
       # it creates a circular dependency.  Based on Sprig documentation, we only need to define
       # the association in one direction
       # (https://github.com/vigetlabs/sprig#has-and-belongs-to-many), so we delete one of them.
 
       self.each do |(model, dependencies)|
-        model.reflect_on_all_associations(:has_and_belongs_to_many).map do |association|
+        model.reflect_on_all_associations(:has_and_belongs_to_many).each do |association|
           if dependencies.include? association.klass
             self[association.klass] = self[association.klass] - [model]
           end

--- a/lib/sprig/reap/tsortable_hash.rb
+++ b/lib/sprig/reap/tsortable_hash.rb
@@ -7,5 +7,20 @@ module Sprig::Reap
     def tsort_each_child(node, &block)
       fetch(node).each(&block)
     end
+
+    def resolve_circular_hatbm_dependencies!
+      # When two models each have a `has_and_belongs_to_many` association pointing to the other,
+      # it creates a circular dependency.  Based on Sprig documentation, we only need to define
+      # the association in one direction
+      # (https://github.com/vigetlabs/sprig#has-and-belongs-to-many), so we delete one of them.
+
+      self.each do |(model, dependencies)|
+        model.reflect_on_all_associations(:has_and_belongs_to_many).map do |association|
+          if dependencies.include? association.klass
+            self[association.klass] = self[association.klass] - [model]
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/sprig/reap/value.rb
+++ b/lib/sprig/reap/value.rb
@@ -1,0 +1,70 @@
+module Sprig::Reap
+  class Value
+    attr_reader :sprig_record, :record, :attribute, :value, :raw_value
+
+    delegate :model, :sprig_id, :to => :sprig_record
+
+    def self.for(sprig_record, attribute)
+      new(sprig_record, attribute).for_sprig_file
+    end
+
+    def initialize(sprig_record, attribute)
+      @sprig_record = sprig_record
+      @record       = sprig_record.record
+      @attribute    = attribute
+      @value        = record.send(attribute)
+      @raw_value    = record.read_attribute(attribute)
+    end
+
+    def for_sprig_file
+      @for_sprig_file ||= dependency? ? sprig_dependency_reference : read_attribute
+    end
+
+    private
+
+    # Normalizes has-and-belongs-to-many attributes, which come in as `tag_ids`
+    # We want to check for association FKs matching `tag_id`
+    def normalized_foreign_key
+      @normalized_foreign_key ||= attribute.singularize
+    end
+
+    def dependency?
+      normalized_foreign_key.in? model.associations.map(&:foreign_key)
+    end
+
+    def association
+      @association ||= model.associations.detect { |a| a.foreign_key == normalized_foreign_key }
+    end
+
+    def klass
+      @klass ||= if association.polymorphic?
+        record.send(association.polymorphic_type).constantize
+      else
+        association.klass
+      end
+    end
+
+    def sprig_dependency_reference
+      references = Array(value).map do |id|
+        sprig_id = Model.find(klass, id).try(:sprig_id)
+
+        sprig_record_reference(klass, sprig_id)
+      end
+
+      # For proper Sprig file formatting, need to return an array for HABTM
+      association.has_and_belongs_to_many? ? references : references.first
+    end
+
+    def sprig_record_reference(klass, sprig_id)
+      return if sprig_id.nil?
+
+      "<%= sprig_record(#{klass}, #{sprig_id}).id %>"
+    end
+
+    def read_attribute
+      file_attr = FileAttribute.new(value)
+
+      file_attr.file.try(:sprig_location) || raw_value
+    end
+  end
+end

--- a/spec/fixtures/models/post.rb
+++ b/spec/fixtures/models/post.rb
@@ -3,6 +3,8 @@ class Post < ActiveRecord::Base
 
   has_many :votes, :as => :votable
 
+  has_and_belongs_to_many :tags
+
   def title
     WrappedAttribute.new(self[:title])
   end

--- a/spec/fixtures/models/tag.rb
+++ b/spec/fixtures/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ActiveRecord::Base
+  has_and_belongs_to_many :posts
+end

--- a/spec/lib/sprig/reap/association_spec.rb
+++ b/spec/lib/sprig/reap/association_spec.rb
@@ -9,6 +9,7 @@ describe Sprig::Reap::Association do
   let(:standard_association)    { Comment.reflect_on_all_associations(:belongs_to).first }
   let(:class_named_association) { Post.reflect_on_all_associations(:belongs_to).first }
   let(:polymorphic_association) { Vote.reflect_on_all_associations(:belongs_to).first }
+  let(:habtm_association)       { Tag.reflect_on_all_associations(:has_and_belongs_to_many).first }
 
   describe "#polymorphic?" do
     context "when given a non-polymorphic dependency" do
@@ -121,6 +122,48 @@ describe Sprig::Reap::Association do
       subject { described_class.new(standard_association) }
 
       its(:polymorphic_type) { should == nil }
+    end
+  end
+
+  describe "#has_and_belongs_to_many?" do
+    context "when the association is a has-and-belongs-to-many" do
+      subject { described_class.new(habtm_association) }
+
+      its(:has_and_belongs_to_many?) { should == true }
+    end
+
+    context "when the association is not a has-and-belongs-to-many" do
+      subject { described_class.new(standard_association) }
+
+      its(:has_and_belongs_to_many?) { should == false }
+    end
+  end
+
+  describe "#has_and_belongs_to_many_attr" do
+    context "when the association is a has-and-belongs-to-many" do
+      subject { described_class.new(habtm_association) }
+
+      its(:has_and_belongs_to_many_attr) { should == 'post_ids' }
+    end
+
+    context "when the association is not a has-and-belongs-to-many" do
+      subject { described_class.new(standard_association) }
+
+      its(:has_and_belongs_to_many_attr) { should == nil }
+    end
+  end
+
+  describe "#foreign_key" do
+    context "when the association is a has-and-belongs-to-many" do
+      subject { described_class.new(habtm_association) }
+
+      its(:foreign_key) { should == 'post_id' }
+    end
+
+    context "when the association is not a has-and-belongs-to-many" do
+      subject { described_class.new(class_named_association) }
+
+      its(:foreign_key) { should == 'poster_id' }
     end
   end
 end

--- a/spec/lib/sprig/reap/model_spec.rb
+++ b/spec/lib/sprig/reap/model_spec.rb
@@ -73,20 +73,20 @@ describe Sprig::Reap::Model do
       its(:dependencies) { should == [Post] }
     end
 
-    context "when the model has a dependency with an explicit :class_name" do
+    context "when the model has a HABTM dependency or a dependency with an explicit :class_name" do
       subject { described_class.new(Post) }
 
-      its(:dependencies) { should == [User] }
+      its(:dependencies) { should == [User, Tag] }
     end
   end
 
   describe "#associations" do
-    let(:association) { double('Association') }
+    let(:association) { double('Association', macro: :belongs_to) }
 
     subject { described_class.new(Post) }
 
     before do
-      Post.stub(:reflect_on_all_associations).with(:belongs_to).and_return([association])
+      Post.stub(:reflect_on_all_associations).and_return([association])
     end
 
     it "creates an Association object for each belongs to association the model has" do

--- a/spec/lib/sprig/reap/model_spec.rb
+++ b/spec/lib/sprig/reap/model_spec.rb
@@ -7,12 +7,13 @@ describe Sprig::Reap::Model do
         described_class.new(User),
         described_class.new(Post),
         described_class.new(Comment),
-        described_class.new(Vote)
+        described_class.new(Vote),
+        described_class.new(Tag)
       ]
     end
 
     before do
-      Sprig::Reap.stub(:classes).and_return([Comment, Post, User, Vote])
+      Sprig::Reap.stub(:classes).and_return([Comment, Post, User, Vote, Tag])
     end
 
     it "returns an dependency-sorted array of Sprig::Reap::Models" do

--- a/spec/lib/sprig/reap/model_spec.rb
+++ b/spec/lib/sprig/reap/model_spec.rb
@@ -5,10 +5,10 @@ describe Sprig::Reap::Model do
     let(:all_models) do
       [
         described_class.new(User),
+        described_class.new(Tag),
         described_class.new(Post),
         described_class.new(Comment),
-        described_class.new(Vote),
-        described_class.new(Tag)
+        described_class.new(Vote)
       ]
     end
 

--- a/spec/lib/sprig/reap/record_spec.rb
+++ b/spec/lib/sprig/reap/record_spec.rb
@@ -23,6 +23,7 @@ describe Sprig::Reap::Record do
                 :published => false)
   end
 
+  let!(:tag)    { Tag.create(name: 'Awesome', post_ids: [post.id]) }
   let!(:models) { Sprig::Reap::Model.all }
   let!(:model)  { models.find { |model| model.klass == Post } }
 
@@ -50,6 +51,7 @@ describe Sprig::Reap::Record do
         content
         published
         poster_id
+        tag_ids
       )
     end
   end
@@ -63,7 +65,8 @@ describe Sprig::Reap::Record do
         'title'     => 'Such Title',
         'content'   => 'Very Content',
         'published' => true,
-        'poster_id' => "<%= sprig_record(User, #{user.id}).id %>"
+        'poster_id' => "<%= sprig_record(User, #{user.id}).id %>",
+        'tag_ids'   => ["<%= sprig_record(Tag, #{tag.id}).id %>"]
       }
     end
 
@@ -76,7 +79,8 @@ describe Sprig::Reap::Record do
           'title'     => 'Wow Title',
           'content'   => 'Much Content',
           'published' => false,
-          'poster_id' => nil
+          'poster_id' => nil,
+          'tag_ids'   => []
         }
       end
     end

--- a/spec/lib/sprig/reap/tsortable_hash_spec.rb
+++ b/spec/lib/sprig/reap/tsortable_hash_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Sprig::Reap::TsortableHash do
-  describe "#resolve_circular_hatbm_dependencies!" do
+  describe "#resolve_circular_habtm_dependencies!" do
     subject do
       described_class.new.merge(
         Comment => [Post],
@@ -13,7 +13,7 @@ describe Sprig::Reap::TsortableHash do
     end
 
     it "trims out circular dependencies resulting from has-and-belongs-to-many" do
-      subject.resolve_circular_hatbm_dependencies!
+      subject.resolve_circular_habtm_dependencies!
       
       subject.should == {
         Comment => [Post],

--- a/spec/lib/sprig/reap/tsortable_hash_spec.rb
+++ b/spec/lib/sprig/reap/tsortable_hash_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Sprig::Reap::TsortableHash do
+  describe "#resolve_circular_hatbm_dependencies!" do
+    subject do
+      described_class.new.merge(
+        Comment => [Post],
+        Post    => [User, Tag],
+        Tag     => [Post],
+        User    => [],
+        Vote    => [Post]
+      )
+    end
+
+    it "trims out circular dependencies resulting from has-and-belongs-to-many" do
+      subject.resolve_circular_hatbm_dependencies!
+      
+      subject.should == {
+        Comment => [Post],
+        Post    => [User, Tag],
+        Tag     => [],
+        User    => [],
+        Vote    => [Post]
+      }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,3 +53,6 @@ Comment.connection.execute "CREATE TABLE comments (id INTEGER PRIMARY KEY , post
 
 Vote.connection.execute "DROP TABLE IF EXISTS votes;"
 Vote.connection.execute "CREATE TABLE votes (id INTEGER PRIMARY KEY, votable_id INTEGER, votable_type VARCHAR(255));"
+
+Tag.connection.execute "DROP TABLE IF EXISTS tags;"
+Tag.connection.execute "CREATE TABLE tags (id INTEGER PRIMARY KEY, vote_id INTEGER, tag_id INTEGER);"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,4 +55,7 @@ Vote.connection.execute "DROP TABLE IF EXISTS votes;"
 Vote.connection.execute "CREATE TABLE votes (id INTEGER PRIMARY KEY, votable_id INTEGER, votable_type VARCHAR(255));"
 
 Tag.connection.execute "DROP TABLE IF EXISTS tags;"
-Tag.connection.execute "CREATE TABLE tags (id INTEGER PRIMARY KEY, vote_id INTEGER, tag_id INTEGER);"
+Tag.connection.execute "CREATE TABLE tags (id INTEGER PRIMARY KEY, name VARCHAR(255));"
+
+Tag.connection.execute "DROP TABLE IF EXISTS posts_tags;"
+Tag.connection.execute "CREATE TABLE posts_tags (id INTEGER PRIMARY KEY, post_id INTEGER, tag_id INTEGER);"


### PR DESCRIPTION
This PR addresses and fixes #19, which was a question as to how Sprig Reap works with `has_and_belongs_to_many` (HABTM) associations.  It didn't, but now it does.

HABTM is some hackery in general, so there's definitely some trickiness/wonkiness to this PR -- mainly around resolving circular dependencies when there are bi-directional HABTM between two models.

The `Sprig::Reap::Record.to_hash` will generate the appropriate hash structure so that it'll generate Sprig-compatible YAML per [Sprig's documentation on HABTM](https://github.com/vigetlabs/sprig#has-and-belongs-to-many).