### PR TITLE
Allow Both Models and ActiveRecord::Relations as Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ Sprig.reap(target_env: 'integration')
 
 #### Model List
 If you only want to `reap` a subset of your models, you may provide a list of models
-(`ActiveRecord::Base.subclasses`-only) you want seed files for:
+(`ActiveRecord::Base.subclasses`-only) or `ActiveRecord::Relations` (for pulling records based on
+scope):
 ```
 # Rake Task
-rake db:seed:reap MODELS=User,Post
+rake db:seed:reap MODELS=User,Post.published
 
 # Rails Console
-Sprig.reap(models: [User, Post])
+Sprig.reap(models: [User, Post.published])
 ```
 
 #### Ignored Attributes
@@ -84,10 +85,10 @@ Sprig.reap(omit_empty_attrs: true)
 You're free to take or leave as many options as you'd like:
 ```
 # Rake Task
-rake db:seed:reap TARGET_ENV=integration MODELS=User,Post IGNORED_ATTRS=created_at,updated_at OMIT_EMPTY_ATTRS=true
+rake db:seed:reap TARGET_ENV=integration MODELS=User,Post.published IGNORED_ATTRS=created_at,updated_at OMIT_EMPTY_ATTRS=true
 
 # Rails Console
-Sprig.reap(target_env: 'integration', models: [User, Post], ignored_attrs: [:created_at, :updated_at], omit_empty_attrs: true)
+Sprig.reap(target_env: 'integration', models: [User, Post.published], ignored_attrs: [:created_at, :updated_at], omit_empty_attrs: true)
 ```
 
 ### Adding to Existing Seed Files (`.yaml` only)

--- a/lib/sprig/reap.rb
+++ b/lib/sprig/reap.rb
@@ -21,7 +21,7 @@ module Sprig::Reap
 
       configure do |config|
         config.target_env       = options[:target_env]       || options['TARGET_ENV']
-        config.classes          = options[:models]           || options['MODELS']
+        config.models           = options[:models]           || options['MODELS']
         config.ignored_attrs    = options[:ignored_attrs]    || options['IGNORED_ATTRS']
         config.omit_empty_attrs = options[:omit_empty_attrs] || options['OMIT_EMPTY_ATTRS']
       end
@@ -42,7 +42,7 @@ module Sprig::Reap
     cattr_reader :configuration
 
     delegate :target_env,
-             :classes,
+             :models,
              :ignored_attrs,
              :logger,
              :omit_empty_attrs,

--- a/lib/sprig/reap.rb
+++ b/lib/sprig/reap.rb
@@ -3,6 +3,7 @@ require "sprig/reap/railtie"
 
 module Sprig::Reap
   autoload :TsortableHash, 'sprig/reap/tsortable_hash'
+  autoload :Inputs,        'sprig/reap/inputs'
   autoload :Configuration, 'sprig/reap/configuration'
   autoload :Model,         'sprig/reap/model'
   autoload :Association,   'sprig/reap/association'

--- a/lib/sprig/reap/configuration.rb
+++ b/lib/sprig/reap/configuration.rb
@@ -2,31 +2,27 @@ module Sprig::Reap
   class Configuration
 
     def target_env
-      @target_env ||= Rails.env
+      @target_env ||= Sprig::Reap::Inputs::Environment.default
     end
 
-    def target_env=(given_env)
-      parse_valid_env_from given_env do |target_environment|
-        @target_env = target_environment
-      end
+    def target_env=(input)
+       @target_env = Sprig::Reap::Inputs::Environment.parse(input)
     end
 
-    def classes
-      @classes ||= valid_classes
+    def models
+      @classes ||= Sprig::Reap::Inputs::Model.default
     end
 
-    def classes=(given_classes)
-      parse_valid_classes_from given_classes do |classes|
-        @classes = classes
-      end
+    def models=(input)
+      @classes ||= Sprig::Reap::Inputs::Model.parse(input)
     end
 
     def ignored_attrs
-      @ignored_attrs ||= []
+      @ignored_attrs ||= Sprig::Reap::Inputs::IgnoredAttrs.default
     end
 
     def ignored_attrs=(input)
-      @ignored_attrs = parse_ignored_attrs_from(input)
+      @ignored_attrs = Sprig::Reap::Inputs::IgnoredAttrs.parse(input)
     end
 
     def logger
@@ -39,59 +35,6 @@ module Sprig::Reap
 
     def omit_empty_attrs=(input)
       @omit_empty_attrs = true if String(input).strip.downcase == 'true'
-    end
-
-    private
-
-    def valid_classes
-      @valid_classes ||= begin
-        Rails.application.eager_load!
-        ActiveRecord::Base.subclasses
-      end
-    end
-
-    def parse_valid_env_from(input)
-      return if input.nil?
-      target_environment = input.to_s.strip.downcase
-      create_seeds_folder(target_environment)
-      yield target_environment
-    end
-
-    def create_seeds_folder(target_env)
-      folder = Rails.root.join('db', 'seeds', target_env)
-      FileUtils.mkdir_p(folder) unless File.directory? folder
-    end
-
-    def parse_valid_classes_from(input)
-      return if input.nil?
-
-      classes = if input.is_a? String
-        input.split(',').map { |klass_string| klass_string.strip.classify.constantize }
-      else
-        input
-      end
-
-      validate_classes(classes)
-
-      yield classes
-    end
-
-    def validate_classes(classes)
-      classes.each do |klass|
-        unless valid_classes.include? klass
-          raise ArgumentError, "Cannot create a seed file for #{klass} because it is not a subclass of ActiveRecord::Base."
-        end
-      end
-    end
-
-    def parse_ignored_attrs_from(input)
-      return if input.nil?
-
-      if input.is_a? String
-        input.split(',').map(&:strip)
-      else
-        input.map(&:to_s).map(&:strip)
-      end
     end
   end
 end

--- a/lib/sprig/reap/inputs.rb
+++ b/lib/sprig/reap/inputs.rb
@@ -1,0 +1,7 @@
+module Sprig::Reap
+  module Inputs
+    autoload :Environment,  'sprig/reap/inputs/environment'
+    autoload :Model,        'sprig/reap/inputs/model'
+    autoload :IgnoredAttrs, 'sprig/reap/inputs/ignored_attrs'
+  end
+end

--- a/lib/sprig/reap/inputs.rb
+++ b/lib/sprig/reap/inputs.rb
@@ -3,5 +3,11 @@ module Sprig::Reap
     autoload :Environment,  'sprig/reap/inputs/environment'
     autoload :Model,        'sprig/reap/inputs/model'
     autoload :IgnoredAttrs, 'sprig/reap/inputs/ignored_attrs'
+
+    module_function
+
+    def Model(input)
+      input.is_a?(Model) ? input : Model.new(input)
+    end
   end
 end

--- a/lib/sprig/reap/inputs/environment.rb
+++ b/lib/sprig/reap/inputs/environment.rb
@@ -1,0 +1,24 @@
+module Sprig::Reap::Inputs
+  class Environment
+    attr_reader :input
+
+    def self.default
+      new().env
+    end
+
+    def self.parse(input)
+      new(input).env
+    end
+
+    def initialize(input = nil)
+      @input = input || Rails.env
+    end
+
+    def env
+      input.to_s.strip.downcase.tap do |target_env|
+        folder = Rails.root.join('db', 'seeds', target_env)
+        FileUtils.mkdir_p(folder) unless File.directory? folder
+      end
+    end
+  end
+end

--- a/lib/sprig/reap/inputs/ignored_attrs.rb
+++ b/lib/sprig/reap/inputs/ignored_attrs.rb
@@ -1,0 +1,23 @@
+module Sprig::Reap::Inputs
+  class IgnoredAttrs
+    attr_reader :input
+
+    def self.default
+      new().list
+    end
+
+    def self.parse(input)
+      new(input).list
+    end
+
+    def initialize(input = nil)
+      @input = input || []
+    end
+
+    def list
+      collection = input.is_a?(String) ? input.split(',') : Array(input)
+
+      collection.map(&:to_s).map(&:strip)
+    end
+  end
+end

--- a/lib/sprig/reap/inputs/model.rb
+++ b/lib/sprig/reap/inputs/model.rb
@@ -1,0 +1,54 @@
+module Sprig::Reap::Inputs
+  class Model
+    attr_reader :input
+
+    def self.valid_classes
+      @@valid_classes ||= begin
+        Rails.application.eager_load!
+        ActiveRecord::Base.subclasses
+      end
+    end
+
+    def self.default
+      valid_classes.map(&to_model_inputs)
+    end
+
+    def self.parse(input)
+      collection = if input.is_a? String
+        input.split(',').map { |string| string.strip }
+      elsif input.is_a? ActiveRecord::Relation
+        [input]
+      else
+        Array(input)
+      end
+
+      collection.map(&to_model_inputs)
+    end
+
+    def initialize(input)
+      @input = input.is_a?(String) ? eval(input) : input
+
+      validate!
+    end
+
+    def klass
+      @klass ||= input.is_a?(ActiveRecord::Relation) ? input.klass : input
+    end
+
+    private
+
+    def self.to_model_inputs
+      proc { |input| new(input) }
+    end
+
+    def valid_classes
+      self.class.valid_classes
+    end
+
+    def validate!
+      if valid_classes.exclude? klass
+        raise ArgumentError, "Cannot create a seed file for #{klass} because it is not a subclass of ActiveRecord::Base."
+      end
+    end
+  end
+end

--- a/lib/sprig/reap/inputs/model.rb
+++ b/lib/sprig/reap/inputs/model.rb
@@ -32,7 +32,11 @@ module Sprig::Reap::Inputs
     end
 
     def klass
-      @klass ||= input.is_a?(ActiveRecord::Relation) ? input.klass : input
+      @klass ||= relation? ? input.klass : input
+    end
+
+    def records
+      relation? ? input : input.all
     end
 
     private
@@ -49,6 +53,10 @@ module Sprig::Reap::Inputs
       if valid_classes.exclude? klass
         raise ArgumentError, "Cannot create a seed file for #{klass} because it is not a subclass of ActiveRecord::Base."
       end
+    end
+
+    def relation?
+      input.is_a? ActiveRecord::Relation
     end
   end
 end

--- a/lib/sprig/reap/model.rb
+++ b/lib/sprig/reap/model.rb
@@ -1,10 +1,11 @@
 module Sprig::Reap
   class Model
     include Logging
+    include Inputs
 
     def self.all
       @@all ||= begin
-        models = Sprig::Reap.classes.map { |klass| new(klass) }
+        models = Sprig::Reap.models.map { |model_input| new(model_input) }
 
         tsorted_classes(models).map do |klass|
           models.find { |model| model.klass == klass }
@@ -16,11 +17,12 @@ module Sprig::Reap
       all.find { |model| model.klass == klass }.find(id)
     end
 
-    attr_reader :klass
+    attr_reader :model_input, :klass
     attr_writer :existing_sprig_ids
 
-    def initialize(klass)
-      @klass = klass
+    def initialize(model_input)
+      @model_input = Sprig::Reap::Inputs.Model(model_input)
+      @klass       = @model_input.klass
     end
 
     def attributes
@@ -69,7 +71,7 @@ module Sprig::Reap
     end
 
     def records
-      @records ||= klass.all.map { |record| Record.new(record, self) }
+      @records ||= model_input.records.map { |record| Record.new(record, self) }
     rescue => e
       log_error "Encountered an error when pulling the database records for #{to_s}:\r#{e.message}"
       []

--- a/spec/fixtures/models/comment.rb
+++ b/spec/fixtures/models/comment.rb
@@ -2,4 +2,6 @@ class Comment < ActiveRecord::Base
   belongs_to :post
 
   validates :post, :presence => true
+
+  has_many :votes, :as => :votable
 end

--- a/spec/fixtures/models/post.rb
+++ b/spec/fixtures/models/post.rb
@@ -5,6 +5,9 @@ class Post < ActiveRecord::Base
 
   has_and_belongs_to_many :tags
 
+  scope :published,    -> { where(:published => true) }
+  scope :with_content, -> { where('content IS NOT NULL') }
+
   def title
     WrappedAttribute.new(self[:title])
   end

--- a/spec/lib/sprig/reap/association_spec.rb
+++ b/spec/lib/sprig/reap/association_spec.rb
@@ -55,7 +55,7 @@ describe Sprig::Reap::Association do
     context "when the association is polymorphic" do
       subject { described_class.new(polymorphic_association) }
 
-      its(:polymorphic_dependencies) { should == [Post] }
+      its(:polymorphic_dependencies) { should =~ [Post, Comment] }
     end
   end
 
@@ -81,7 +81,7 @@ describe Sprig::Reap::Association do
     context "when the association is polymorphic" do
       subject { described_class.new(polymorphic_association) }
 
-      its(:dependencies) { should == [Post] }
+      its(:dependencies) { should =~ [Post, Comment] }
     end
 
     context "when the association is not polymorphic" do

--- a/spec/lib/sprig/reap/configuration_spec.rb
+++ b/spec/lib/sprig/reap/configuration_spec.rb
@@ -8,140 +8,56 @@ describe Sprig::Reap::Configuration do
   end
 
   describe "#target_env" do
-    context "from a fresh configuration" do
-      its(:target_env) { should == Rails.env }
+    context "given a fresh configuration" do
+      it "grabs the default" do
+        Sprig::Reap::Inputs::Environment.should_receive(:default)
+
+        subject.target_env
+      end
     end
   end
 
   describe "#target_env=" do
-    context "when given nil" do
-      it "does not change the target_env" do
-        subject.target_env = nil
+    it "parses the input" do
+      Sprig::Reap::Inputs::Environment.should_receive(:parse).with(:shaboosh)
 
-        subject.target_env.should_not == nil
-      end
+      subject.target_env = :shaboosh
     end
+  end
 
-    context "given a non-nil string value" do
-      let(:input) { ' ShaBOOSH' }
+  describe "#models" do
+    context "given a fresh configuration" do
+      it "grabs the default" do
+        Sprig::Reap::Inputs::Model.should_receive(:default)
 
-      it "formats the given value and then sets the target environment" do
-        subject.target_env = input
-
-        subject.target_env.should == 'shaboosh'
-      end
-
-      context "and the corresponding seeds folder does not yet exist" do
-        after do
-          FileUtils.remove_dir('./spec/fixtures/db/seeds/shaboosh')
-        end
-
-        it "creates the seeds folder" do
-          subject.target_env = input
-
-          File.directory?('./spec/fixtures/db/seeds/shaboosh').should == true
-        end
-      end
-    end
-
-    context "given a non-nil symbol value" do
-      let(:input) { :shaboosh }
-
-      it "formats the given value and then sets the target environment" do
-        subject.target_env = input
-
-        subject.target_env.should == 'shaboosh'
-      end
-
-      context "and the corresponding seeds folder does not yet exist" do
-        after do
-          FileUtils.remove_dir('./spec/fixtures/db/seeds/shaboosh')
-        end
-
-        it "creates the seeds folder" do
-          subject.target_env = input
-
-          File.directory?('./spec/fixtures/db/seeds/shaboosh').should == true
-        end
+        subject.models
       end
     end
   end
 
-  describe "#classes" do
-    context "from a fresh configuration" do
-      its(:classes) { should == ActiveRecord::Base.subclasses }
-    end
-  end
+  describe "#models=" do
+    it "parses the input" do
+      Sprig::Reap::Inputs::Model.should_receive(:parse).with(Post)
 
-  describe "#classes=" do
-    context "when given nil" do
-      it "does not set classes to nil" do
-        subject.classes = nil
-
-        subject.classes.should_not == nil
-      end
-    end
-
-    context "when given an array of classes" do
-      context "where one or more classes are not subclasses of ActiveRecord::Base" do
-        it "raises an error" do
-          expect {
-            subject.classes = [Comment, Sprig::Reap::Model]
-          }.to raise_error ArgumentError, 'Cannot create a seed file for Sprig::Reap::Model because it is not a subclass of ActiveRecord::Base.'
-        end
-      end
-
-      context "where all classes are subclasses of ActiveRecord::Base" do
-        it "sets classes to the given input" do
-          subject.classes = [Comment, Post]
-
-          subject.classes.should == [Comment, Post]
-        end
-      end
-    end
-
-    context "when given a string" do
-      context "where one or more classes are not subclasses of ActiveRecord::Base" do
-        it "raises an error" do
-          expect {
-            subject.classes = 'Sprig::Reap::Model'
-          }.to raise_error ArgumentError, 'Cannot create a seed file for Sprig::Reap::Model because it is not a subclass of ActiveRecord::Base.'
-        end
-      end
-
-      context "where all classes are subclasses of ActiveRecord::Base" do
-        it "sets classes to the parsed input" do
-          subject.classes = ' comment, post'
-
-          subject.classes.should == [Comment, Post]
-        end
-      end
+      subject.models = Post
     end
   end
 
   describe "#ignored_attrs" do
-    context "from a fresh configuration" do
-      its(:ignored_attrs) { should == [] }
+    context "given a fresh configuration" do
+      it "grabs the default" do
+        Sprig::Reap::Inputs::IgnoredAttrs.should_receive(:default)
+
+        subject.ignored_attrs
+      end
     end
   end
 
   describe "#ignored_attrs=" do
-    context "when given nil" do
-      before { subject.ignored_attrs = nil }
+    it "parses the input" do
+      Sprig::Reap::Inputs::IgnoredAttrs.should_receive(:parse).with('boom, shaka, laka')
 
-      its(:ignored_attrs) { should == [] }
-    end
-
-    context "when given an array of ignored_attrs" do
-      before { subject.ignored_attrs = [:shaka, ' laka '] }
-
-      its(:ignored_attrs) { should == ['shaka', 'laka'] }
-    end
-
-    context "when given a string" do
-      before { subject.ignored_attrs = ' shaka, laka' }
-
-      its(:ignored_attrs) { should == ['shaka', 'laka'] }
+      subject.ignored_attrs = 'boom, shaka, laka'
     end
   end
 

--- a/spec/lib/sprig/reap/inputs/environment_spec.rb
+++ b/spec/lib/sprig/reap/inputs/environment_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe Sprig::Reap::Inputs::Environment do
+  before do
+    stub_rails_root
+  end
+
+  describe ".default" do
+    subject { described_class }
+
+    its(:default) { should == 'test' }
+  end
+
+  describe ".parse" do
+    let(:environment) { double('Sprig::Reap::Inputs::Environment') }
+
+    before do
+      Sprig::Reap::Inputs::Environment.stub(:new).with(:shaboosh).and_return(environment)
+    end
+
+    it "instantiates a Sprig::Reap::Inputs::Environment and returns the env from it" do
+      environment.should_receive(:env)
+
+      described_class.parse(:shaboosh)
+    end
+  end
+
+  describe "#env" do
+    context "when no input is given" do
+      subject { described_class.new }
+
+      its(:env) { should == 'test' }
+    end
+
+    context "when the input is a blank value" do
+      subject { described_class.new(nil) }
+
+      its(:env) { should == 'test' }
+    end
+
+    context "when the input is a string" do
+      subject { described_class.new(' ShaBOOSH') }
+
+      it "formats the given value and then sets the target environment" do
+        subject.env.should == 'shaboosh'
+      end
+
+      context "and the corresponding seeds folder does not yet exist" do
+        after do
+          FileUtils.remove_dir('./spec/fixtures/db/seeds/shaboosh')
+        end
+
+        it "creates the seeds folder" do
+          subject.env
+
+          File.directory?('./spec/fixtures/db/seeds/shaboosh').should == true
+        end
+      end
+    end
+
+    context "given a symbol" do
+      subject { described_class.new(:shaboosh) }
+
+      it "formats the given value and then sets the target environment" do
+        subject.env.should == 'shaboosh'
+      end
+
+      context "and the corresponding seeds folder does not yet exist" do
+        after do
+          FileUtils.remove_dir('./spec/fixtures/db/seeds/shaboosh')
+        end
+
+        it "creates the seeds folder" do
+          subject.env
+
+          File.directory?('./spec/fixtures/db/seeds/shaboosh').should == true
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sprig/reap/inputs/ignored_attrs_spec.rb
+++ b/spec/lib/sprig/reap/inputs/ignored_attrs_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Sprig::Reap::Inputs::IgnoredAttrs do
+  describe ".default" do
+    subject { described_class }
+    
+    its(:default) { should == [] }
+  end
+
+  describe ".parse" do
+    let(:input) { 'boom, shaka, laka' }
+    let(:ignored_attrs) { double('Sprig::Reap::Inputs::IgnoredAttrs') }
+
+    before do
+      Sprig::Reap::Inputs::IgnoredAttrs.stub(:new).with(input).and_return(ignored_attrs)
+    end
+
+    it "instantiates a Sprig::Reap::Inputs::IgnoredAttrs with the given input and grabs the list from it" do
+      ignored_attrs.should_receive(:list)
+
+      described_class.parse(input)
+    end
+  end
+
+  describe "#list" do
+    let(:input) { 'boom, shaka, laka' }
+
+    subject { described_class.new(input) }
+
+    its(:list) { should == ['boom', 'shaka', 'laka'] }
+  end
+end

--- a/spec/lib/sprig/reap/inputs/model_spec.rb
+++ b/spec/lib/sprig/reap/inputs/model_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe Sprig::Reap::Inputs::Model do
+  describe ".valid_classes" do
+    subject { described_class }
+
+    its(:valid_classes) { should == ActiveRecord::Base.subclasses }
+  end
+
+  describe ".default" do
+    it "instantiates a Sprig::Reap::Inputs::Model for each model" do
+      ActiveRecord::Base.subclasses.each do |model|
+        Sprig::Reap::Inputs::Model.should_receive(:new).with(model)
+      end
+
+      described_class.default
+    end
+  end
+
+  describe ".parse" do
+    context "given a list in a string" do
+      it "instantiates a Sprig::Reap::Inputs::Model for each piece of input" do
+        Sprig::Reap::Inputs::Model.should_receive(:new).with('User')
+        Sprig::Reap::Inputs::Model.should_receive(:new).with('Post.published')
+        Sprig::Reap::Inputs::Model.should_receive(:new).with('Tag')
+
+        described_class.parse('User, Post.published, Tag')
+      end
+    end
+
+    context "given an array" do
+      it "instantiates a Sprig::Reap::Inputs::Model for each piece of input" do
+        Sprig::Reap::Inputs::Model.should_receive(:new).with(User)
+        Sprig::Reap::Inputs::Model.should_receive(:new).with(Post.published)
+        Sprig::Reap::Inputs::Model.should_receive(:new).with(Tag)
+
+        described_class.parse([User, Post.published, Tag])
+      end
+    end
+
+    context "given a single item" do
+      it "instantiates a Sprig::Reap::Inputs::Model with the input" do
+        Sprig::Reap::Inputs::Model.should_receive(:new).with(Post.published)
+
+        described_class.parse(Post.published)
+      end
+    end
+  end
+
+  describe "#initialize" do
+    context "when the input is a String" do
+      context "representing an ActiveRecord::Base class" do
+        it "does not raise an error" do
+          expect { described_class.new('User') }.to_not raise_error
+        end
+      end
+
+      context "representing an ActiveRecord::Relation" do
+        it "does not raise an error" do
+          expect { described_class.new('Post.published') }.to_not raise_error
+        end
+      end
+
+      context "representing a non-ActiveRecord::Base class" do
+        it "raises an error" do
+          expect { described_class.new('Sprig::Reap::Model') }.to raise_error
+        end
+      end
+
+      context "representing some non-class identifier" do
+        it "raises an error" do
+          expect { described_class.new('klass') }.to raise_error
+        end
+      end
+    end
+
+    context "when the input is a non-ActiveRecord::Base class" do
+      it "raises an error" do
+        expect { described_class.new(Sprig::Reap::Record) }.to raise_error
+      end
+    end
+
+    context "when the input is an ActiveRecord::Base class" do
+      it "does not raise an error" do
+        expect { described_class.new(Tag) }.to_not raise_error
+      end
+    end
+
+    context "when the input is an ActiveRecord::Relation" do
+      it "does not raise an error" do
+        expect { described_class.new(Post.published) }.to_not raise_error
+      end
+    end
+  end
+
+  describe "#klass" do
+    context "when the input is an ActiveRecord::Base class" do
+      subject { described_class.new(Tag) }
+
+      its(:klass) { should == Tag }
+    end
+
+    context "when the input is an ActiveRecord::Relation" do
+      subject { described_class.new(Post.published) }
+
+      its(:klass) { should == Post }
+    end
+  end
+end

--- a/spec/lib/sprig/reap/inputs/model_spec.rb
+++ b/spec/lib/sprig/reap/inputs/model_spec.rb
@@ -106,4 +106,24 @@ describe Sprig::Reap::Inputs::Model do
       its(:klass) { should == Post }
     end
   end
+
+  describe "#records" do
+    let!(:bob)  { User.create(:first_name => 'Bob',  :last_name => 'Costas') }
+    let!(:john) { User.create(:first_name => 'John', :last_name => 'Madden') }
+
+    context "when the input is an ActiveRecord::Base class" do
+      subject { described_class.new(User) }
+
+      its(:records) { should == [bob, john]}
+    end
+
+    context "when the input is an ActiveRecord::Relation" do
+      let!(:unpublished) { Post.create(:published => false, :poster => bob) }
+      let!(:published)   { Post.create(:published => true,  :poster => john) }
+
+      subject { described_class.new(Post.published) }
+
+      its(:records) { should == [published] }
+    end
+  end
 end

--- a/spec/lib/sprig/reap/inputs_spec.rb
+++ b/spec/lib/sprig/reap/inputs_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Sprig::Reap::Inputs do
+  describe "Model()" do
+    context "given a non-Sprig::Reap::Inputs::Model" do
+      it "instantiates a Sprig::Reap::Inputs::Model with the given input" do
+        described_class.Model(Post).should be_an_instance_of Sprig::Reap::Inputs::Model
+      end
+    end
+
+    context "given a Sprig::Reap::Inputs::Model" do
+      let(:input) { Sprig::Reap::Inputs::Model.new(Post) }
+
+      it "returns the given input" do
+        described_class.Model(input).should == input
+      end
+    end
+  end
+end

--- a/spec/lib/sprig/reap/model_spec.rb
+++ b/spec/lib/sprig/reap/model_spec.rb
@@ -12,6 +12,16 @@ describe Sprig::Reap::Model do
       ]
     end
 
+    before do
+      Sprig::Reap.stub(:models).and_return([
+        Sprig::Reap::Inputs::Model.new(Comment),
+        Sprig::Reap::Inputs::Model.new(Post),
+        Sprig::Reap::Inputs::Model.new(User),
+        Sprig::Reap::Inputs::Model.new(Vote),
+        Sprig::Reap::Inputs::Model.new(Tag)
+      ])
+    end
+
     it "returns an dependency-sorted array of Sprig::Reap::Models" do
       described_class.all.all? { |model| model.is_a? Sprig::Reap::Model }.should == true
       described_class.all.map(&:klass).should == all_models.map(&:klass)

--- a/spec/lib/sprig/reap/model_spec.rb
+++ b/spec/lib/sprig/reap/model_spec.rb
@@ -12,10 +12,6 @@ describe Sprig::Reap::Model do
       ]
     end
 
-    before do
-      Sprig::Reap.stub(:classes).and_return([Comment, Post, User, Vote, Tag])
-    end
-
     it "returns an dependency-sorted array of Sprig::Reap::Models" do
       described_class.all.all? { |model| model.is_a? Sprig::Reap::Model }.should == true
       described_class.all.map(&:klass).should == all_models.map(&:klass)

--- a/spec/lib/sprig/reap/model_spec.rb
+++ b/spec/lib/sprig/reap/model_spec.rb
@@ -66,7 +66,7 @@ describe Sprig::Reap::Model do
     context "when the model is polymorphic" do
       subject { described_class.new(Vote) }
 
-      its(:dependencies) { should == [Post] }
+      its(:dependencies) { should =~ [Post, Comment] }
     end
 
     context "when the model has a HABTM dependency or a dependency with an explicit :class_name" do

--- a/spec/lib/sprig/reap_spec.rb
+++ b/spec/lib/sprig/reap_spec.rb
@@ -25,8 +25,8 @@ describe Sprig::Reap do
       subject.reap
     end
 
-    it "generates a seed file for each class" do
-      count = Sprig::Reap.classes.count
+    it "generates a seed file for each model" do
+      count = Sprig::Reap.models.count
 
       seed_file.should_receive(:write).exactly(count).times
 
@@ -49,18 +49,31 @@ describe Sprig::Reap do
       end
     end
 
-    context "when passed a set of classes in the options hash" do
-      context "in :classes" do
-        it "sets the classes" do
+    context "when passed a set of models in the options hash" do
+      context "in :models" do
+        it "sets the models" do
           subject.reap(:models => [User, Post])
-          subject.classes.should == [User, Post]
+
+          subject.models.all? { |model| model.class == Sprig::Reap::Inputs::Model }.should == true
+          subject.models.map(&:klass).should == [User, Post]
         end
       end
 
-      context "sets the classes" do
-        it "passes the value to its configuration" do
+      context "in 'MODELS'" do
+        it "sets the models" do
           subject.reap('MODELS' => 'User, Post')
-          subject.classes.should == [User, Post]
+
+          subject.models.all? { |model| model.class == Sprig::Reap::Inputs::Model }.should == true
+          subject.models.map(&:klass).should == [User, Post]
+        end
+      end
+
+      context "as an ActiveRecord::Relation" do
+        it "sets the relation to one of the models" do
+          subject.reap(:models => [Post.published.with_content])
+
+          subject.models.all? { |model| model.class == Sprig::Reap::Inputs::Model }.should == true
+          subject.models.map(&:klass).should == [Post]
         end
       end
     end


### PR DESCRIPTION
Issue #18 was opened and commented about how Sprig-Reap appears to handle `ActiveRecord::Relation`-type input.  In this PR, I made a pretty minimal number of adjustments in order to accommodate AR-relations.  I also took the opportunity to refactor and clean up some of the code.

Fixes #18.