### PR TITLE
use a newline so error output lines do not get overwritten

### DIFF
--- a/lib/sprig/reap/model.rb
+++ b/lib/sprig/reap/model.rb
@@ -74,7 +74,7 @@ module Sprig::Reap
     def records
       @records ||= model_input.records.map { |record| Record.new(record, self) }
     rescue => e
-      log_error "Encountered an error when pulling the database records for #{to_s}:\r#{e.message}"
+      log_error "Encountered an error when pulling the database records for #{to_s}:\n#{e.message}"
       []
     end
 

--- a/lib/sprig/reap/seed_file.rb
+++ b/lib/sprig/reap/seed_file.rb
@@ -46,7 +46,7 @@ module Sprig::Reap
       end
 
     rescue => e
-      log_error "There was an issue writing to the file for #{model}:\r#{e.message}"
+      log_error "There was an issue writing to the file for #{model}:\n#{e.message}"
     end
 
     def existing_sprig_ids(yaml)

--- a/spec/lib/sprig/reap/model_spec.rb
+++ b/spec/lib/sprig/reap/model_spec.rb
@@ -189,7 +189,7 @@ describe Sprig::Reap::Model do
       end
 
       it "logs an error message" do
-        log_should_receive :error, :with => "Encountered an error when pulling the database records for Post:\rOh snap"
+        log_should_receive :error, :with => "Encountered an error when pulling the database records for Post:\nOh snap"
 
         subject.records
       end

--- a/spec/lib/sprig/reap/seed_file_spec.rb
+++ b/spec/lib/sprig/reap/seed_file_spec.rb
@@ -138,7 +138,7 @@ describe Sprig::Reap::SeedFile do
       end
 
       it "logs an error for the given model" do
-        log_should_receive :error, :with => "There was an issue writing to the file for Comment:\rOh snap"
+        log_should_receive :error, :with => "There was an issue writing to the file for Comment:\nOh snap"
 
         subject.write
       end


### PR DESCRIPTION
my error lines were getting overwritten/clobbered, narrowed it down to a usage of carriage return instead of newline.

For example:
```
2.1.7 :001 > puts "The quick brown fox jumped over the lazy dog\r    WHAT!!!   "
    WHAT!!!   n fox jumped over the lazy dog
 => nil
2.1.7 :002 > puts "The quick brown fox jumped over the lazy dog\n    WHAT!!!   "
The quick brown fox jumped over the lazy dog
    WHAT!!!
 => nil
```

I think this explains the weird error messages in the issue https://github.com/vigetlabs/sprig-reap/issues/24

