### PR TITLE
look up ActiveRecord::Base.descendants instead of .subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Sprig.reap(target_env: 'integration')
 
 #### Model List
 If you only want to `reap` a subset of your models, you may provide a list of models
-(`ActiveRecord::Base.subclasses`-only) or `ActiveRecord::Relations` (for pulling records based on
+(`ActiveRecord::Base.descendants`-only) or `ActiveRecord::Relations` (for pulling records based on
 scope):
 ```
 # Rake Task

--- a/lib/sprig/reap/association.rb
+++ b/lib/sprig/reap/association.rb
@@ -22,7 +22,7 @@ module Sprig::Reap
 
     def polymorphic_dependencies
       return [] unless polymorphic?
-      @polymorphic_dependencies ||= ActiveRecord::Base.subclasses.select { |model| polymorphic_match? model }
+      @polymorphic_dependencies ||= ActiveRecord::Base.descendants.select { |model| polymorphic_match? model }
     end
 
     def polymorphic_match?(model)

--- a/lib/sprig/reap/inputs/model.rb
+++ b/lib/sprig/reap/inputs/model.rb
@@ -5,7 +5,7 @@ module Sprig::Reap::Inputs
     def self.valid_classes
       @@valid_classes ||= begin
         Rails.application.eager_load!
-        ActiveRecord::Base.subclasses
+        ActiveRecord::Base.descendants
       end
     end
 

--- a/spec/lib/sprig/reap/inputs/model_spec.rb
+++ b/spec/lib/sprig/reap/inputs/model_spec.rb
@@ -4,12 +4,12 @@ describe Sprig::Reap::Inputs::Model do
   describe ".valid_classes" do
     subject { described_class }
 
-    its(:valid_classes) { should == ActiveRecord::Base.subclasses }
+    its(:valid_classes) { should == ActiveRecord::Base.descendants }
   end
 
   describe ".default" do
     it "instantiates a Sprig::Reap::Inputs::Model for each model" do
-      ActiveRecord::Base.subclasses.each do |model|
+      ActiveRecord::Base.descendants.each do |model|
         Sprig::Reap::Inputs::Model.should_receive(:new).with(model)
       end
 


### PR DESCRIPTION
## Backstory

In Rails 5, all models inherit from `ApplicationRecord`, which inherits from `ActiveRecord::Base` ( https://github.com/rails/rails/pull/22567 ). For instance, my User model:

```
class User < ApplicationRecord
    # model stuff
end
```

`sprig-reap` looks up models via [`ActiveRecord::Base.subclasses`](http://apidock.com/rails/Class/subclasses), which only looks up direct subclasses of `ActiveRecord::Base`. As a result, `rake db:seed:reap` in Rails 5 fails silently with no records reaped:

```
D, [2016-07-15T11:48:44.342965 #93348] DEBUG -- : Reaping records from the database...
D, [2016-07-15T11:48:44.345559 #93348] DEBUG -- : Finished reaping!
```

Reaping from the Rails console shows the error:

```
$ rake db:seed:reap MODELS=User
rake aborted!
ArgumentError: Cannot create a seed file for User because it is not a subclass of ActiveRecord::Base.

Tasks: TOP => db:seed:reap
(See full trace by running task with --trace)
```
## Change

Using the [`.descendants`](http://apidock.com/rails/Class/descendants) method, however, all levels of subclassing can be accessed, and I can successfully reap all of my models.

Rather than changing sprig-reap to look up direct subclasses of `ApplicationRecord`, I've modified it to call `ActiveRecord::Base.descendants`. This should preserve compatibility with pre-Rails-5 models that inherit directly from `ActiveRecord:Base` and/or don't inherit from `ApplicationRecord`.
